### PR TITLE
Set asset bundle name in AssetBundle constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 
     <properties>
         <compile.level>1.7</compile.level>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Runtime Library Versions -->
         <dropwizard.version>0.7.1</dropwizard.version>

--- a/src/main/java/net/ozwolf/raml/ApiSpecsBundle.java
+++ b/src/main/java/net/ozwolf/raml/ApiSpecsBundle.java
@@ -35,7 +35,7 @@ public class ApiSpecsBundle implements Bundle {
     @Override
     public void initialize(Bootstrap<?> bootstrap) {
         bootstrap.addBundle(new ViewBundle());
-        bootstrap.addBundle(new AssetsBundle("/raml-docs-assets", "/api/assets"));
+        bootstrap.addBundle(new AssetsBundle("/raml-docs-assets", "/api/assets", null, "raml-view"));
     }
 
     @Override


### PR DESCRIPTION
Due to default name being used it causes a bit of trouble overriding
when there are multiple assetbundles configured. see
https://github.com/dropwizard/dropwizard/issues/499

Changed to always have an assetname that's not default.
