### PR TITLE
v4.0.0: upgraded to 0.8.1 of dropwizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DropWizard RAML API Resource Bundle
 
-[![Build Status](https://travis-ci.org/ozwolf-software/dropwizard-raml-view.svg?branch=dropwizard-0.7-jdk-8)](https://travis-ci.org/ozwolf-software/dropwizard-raml-view)
+[![Build Status](https://travis-ci.org/ozwolf-software/dropwizard-raml-view.svg?branch=dropwizard-0.8-jdk-8)](https://travis-ci.org/ozwolf-software/dropwizard-raml-view)
 
 This bundle allows a RAML specification to be attached to the resources of the service, exposing a human-readable, HTML representation of the RAML specification on the `/api` resource.
 
@@ -10,9 +10,12 @@ The RAML specification documentation can be found [`here`](https://github.com/ra
 
 ## Compatability
 
-This project has 3 compatability branches:
+This project has 4 compatability branches:
 
-+ **DropWizard 0.7** for **Java 8** - `LIVE` - New features will be applied primarily to this branch.
++ **DropWizard 0.8** for **Java 8** - `LIVE` - New features will be applied primarily to this branch.
+    + *Version Numbers* 
+        + `4.*`
++ **DropWizard 0.7** for **Java 8** - `MAINTENANCE` - New features will be applied primarily to this branch.
     + *Version Numbers* 
         + `3.*`
 + **DropWizard 0.7** for **Java 7** - `MAINTENANCE` - Only "must-have" features will be applied.

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
     <groupId>net.ozwolf</groupId>
     <artifactId>dropwizard-raml-view</artifactId>
-    <version>3.0.3</version>
+    <version>4.0.0</version>
 
     <properties>
         <compile.level>1.8</compile.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Runtime Library Versions -->
-        <dropwizard.version>0.7.1</dropwizard.version>
+        <dropwizard.version>0.8.1</dropwizard.version>
         <commons.lang.version>3.1</commons.lang.version>
         <commons.codec.version>1.7</commons.codec.version>
         <raml.parser.version>0.8.10</raml.parser.version>


### PR DESCRIPTION
No code changes required, all tests pass

Note: this has to be 0.8.1 or above, and not 0.8.0, because ViewBundle
is abstract in that version