### PR TITLE
Updating dependencies to Dropwizard 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ The RAML specification documentation can be found [`here`](https://github.com/ra
 
 **Note:** This library currently only supports RAML 0.8.
 
-## Compatability
+## Compatibility
 
-This project has 4 compatability branches:
+This project has 5 compatibility branches:
+
++ **DropWizard 1.0.0** for **Java 8** - `PREVIEW` - Experimental branch for new DropWizard 1.0.0 release.
 
 + (**MASTER**) **DropWizard 0.9** for **Java 7** - `LIVE` -  New features will be applied primarily to this branch.
     + *Version Numbers*

--- a/pom.xml
+++ b/pom.xml
@@ -6,21 +6,21 @@
 
     <groupId>net.ozwolf</groupId>
     <artifactId>dropwizard-raml-view</artifactId>
-    <version>0.9.2.1</version>
+    <version>0.9.3.0</version>
 
     <properties>
         <compile.level>1.8</compile.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Runtime Library Versions -->
-        <dropwizard.version>0.9.2</dropwizard.version>
+        <dropwizard.version>1.0.0</dropwizard.version>
         <commons.lang.version>3.1</commons.lang.version>
         <commons.codec.version>1.7</commons.codec.version>
         <raml.parser.version>0.8.14</raml.parser.version>
         <markdown4j.version>2.2-cj-1.0</markdown4j.version>
 
         <!-- Testing Library Versions -->
-        <junit.version>4.11</junit.version>
+        <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.9.5</mockito.version>
 


### PR DESCRIPTION
I've created a `preview` branch for Dropwizard 1.0.0 - if you want to create a new branch called `preview` to pull this into, that'll give you somewhere to put a Dropwizard 1.0.0 compatible version if you intend to maintain the `master` branch with Dropwizard 0.9.2.
